### PR TITLE
Hw complex test case

### DIFF
--- a/Niffler/Niffler.xcodeproj/project.pbxproj
+++ b/Niffler/Niffler.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		A9DAF9032BBBD5C400B941BE /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAF9022BBBD5C400B941BE /* LogoView.swift */; };
 		A9F0B4642B1066AF00E33941 /* SpendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F0B4632B1066AF00E33941 /* SpendsView.swift */; };
 		A9FCA79E2BEB760700A5A1D2 /* PasswordField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FCA79D2BEB760700A5A1D2 /* PasswordField.swift */; };
+		E9E31E2A2DD27EF400A19274 /* Fakery in Frameworks */ = {isa = PBXBuildFile; productRef = E9E31E292DD27EF400A19274 /* Fakery */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,6 +93,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9E31E2A2DD27EF400A19274 /* Fakery in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -231,6 +233,7 @@
 			);
 			name = NifflerUITests;
 			packageProductDependencies = (
+				E9E31E292DD27EF400A19274 /* Fakery */,
 			);
 			productName = NifflerUITests;
 			productReference = E97C2AD82DCA933400A76F49 /* NifflerUITests.xctest */;
@@ -266,6 +269,7 @@
 			mainGroup = 7468536D2B0CAE9700E48DFE;
 			packageReferences = (
 				749E20F42B0CB0070045F4E3 /* XCLocalSwiftPackageReference "Api" */,
+				E9E31E282DD27EF400A19274 /* XCRemoteSwiftPackageReference "Fakery" */,
 			);
 			productRefGroup = 746853772B0CAE9700E48DFE /* Products */;
 			projectDirPath = "";
@@ -597,10 +601,26 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		E9E31E282DD27EF400A19274 /* XCRemoteSwiftPackageReference "Fakery" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/vadymmarkov/Fakery";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		749E20F52B0CB0070045F4E3 /* Api */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Api;
+		};
+		E9E31E292DD27EF400A19274 /* Fakery */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E9E31E282DD27EF400A19274 /* XCRemoteSwiftPackageReference "Fakery" */;
+			productName = Fakery;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Niffler/Niffler.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Niffler/Niffler.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "fakery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vadymmarkov/Fakery",
+      "state" : {
+        "revision" : "71cb3bf36a808534659d1248780c2bf3c4c4fc91",
+        "version" : "5.1.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Niffler/Niffler.xcodeproj/xcshareddata/xcschemes/Niffler.xcscheme
+++ b/Niffler/Niffler.xcodeproj/xcshareddata/xcschemes/Niffler.xcscheme
@@ -50,7 +50,7 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "74D55B762BE12B9600AEF67D"
+               BlueprintIdentifier = "E97C2AD72DCA933400A76F49"
                BuildableName = "NifflerUITests.xctest"
                BlueprintName = "NifflerUITests"
                ReferencedContainer = "container:Niffler.xcodeproj">
@@ -82,27 +82,27 @@
          <EnvironmentVariable
             key = "username"
             value = "stage"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "password"
             value = "12345"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "description"
             value = "Hello kiity"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "amount"
             value = "300"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "selectedCategory"
             value = "&#x420;&#x44b;&#x431;&#x430;&#x43b;&#x43a;&#x430;"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/Niffler/Niffler.xctestplan
+++ b/Niffler/Niffler.xctestplan
@@ -33,9 +33,6 @@
       }
     },
     {
-      "skippedTests" : [
-        "AuthTests\/test_registerAndAuthorize()"
-      ],
       "target" : {
         "containerPath" : "container:Api",
         "identifier" : "ApiTests",

--- a/Niffler/Niffler/NifflerApp.swift
+++ b/Niffler/Niffler/NifflerApp.swift
@@ -25,6 +25,8 @@ struct NifflerApp: App {
     
     func setupForUITests() {
         if ProcessInfo.processInfo.arguments.contains("RemoveAuthOnStart") {
+            let removeDate = Date().addingTimeInterval(-2*60*60)
+            HTTPCookieStorage.shared.removeCookies(since: removeDate)
             Auth.removeAuth()
             UIView.setAnimationsEnabled(false)
             UIApplication.shared.keyWindow?.layer.speed = 100

--- a/Niffler/NifflerUITests/NifflerUITests.swift
+++ b/Niffler/NifflerUITests/NifflerUITests.swift
@@ -52,18 +52,20 @@ final class NifflerUITests: XCTestCase {
     }
     
     private func addNewSpend(_ description: String) {
-        app.buttons["addSpendButton"].tap()
-        app.textFields["amountField"].tap()
-        app.textFields["amountField"].typeText("100")
-        app.textFields["descriptionField"].tap()
-        app.textFields["descriptionField"].typeText(description)
-        if "+ New category" == app.otherElements["Select category"].label {
-            app.otherElements["Select category"].tap()
-            app.alerts.textFields.firstMatch.tap()
-            app.alerts.textFields.firstMatch.typeText(faker.car.brand())
-            app.alerts.buttons["Add"].tap()
+        XCTContext.runActivity(named: "Adding spend with description: \(description)") { _ in
+            app.buttons["addSpendButton"].tap()
+            app.textFields["amountField"].tap()
+            app.textFields["amountField"].typeText("100")
+            app.textFields["descriptionField"].tap()
+            app.textFields["descriptionField"].typeText(description)
+            if "+ New category" == app.otherElements["Select category"].label {
+                app.otherElements["Select category"].tap()
+                app.alerts.textFields.firstMatch.tap()
+                app.alerts.textFields.firstMatch.typeText(faker.car.brand())
+                app.alerts.buttons["Add"].tap()
+            }
+            app.buttons["Add"].tap()
         }
-        app.buttons["Add"].tap()
     }
     
     fileprivate func login(username: String, password: String) {

--- a/Niffler/NifflerUITests/NifflerUITests.swift
+++ b/Niffler/NifflerUITests/NifflerUITests.swift
@@ -75,6 +75,7 @@ final class NifflerUITests: XCTestCase {
     
     private func pressCreateNewAccountButton() {
         XCTContext.runActivity(named: "Press button 'Create new account'") { _ in
+            app.hideKeyboardIfPresent()
             app.staticTexts["Create new account"].tap()
         }
     }
@@ -87,7 +88,7 @@ final class NifflerUITests: XCTestCase {
     
     private func assertLoginField(_ expectedLogin: String, file: StaticString = #filePath, line: UInt = #line) {
         XCTContext.runActivity(named: "Assert that login has value '\(expectedLogin)'") { _ in
-            let inputLogin = app.textFields.matching(identifier: "userNameTextField").element(boundBy: 0)
+            let inputLogin = app.textFields.matching(identifier: "userNameTextField").firstMatch
             XCTAssertEqual(inputLogin.value as? String, expectedLogin,
                            "Login field value is wrong",
                            file: file,
@@ -97,7 +98,7 @@ final class NifflerUITests: XCTestCase {
     
     private func assertPasswordField(_ password: String, file: StaticString = #filePath, line: UInt = #line) {
         XCTContext.runActivity(named: "Assert that password has value '\(password)'") { _ in
-            app.buttons.matching(identifier: "passwordTextField").element(boundBy: 0).tap()
+            app.buttons.matching(identifier: "passwordTextField").firstMatch.tap()
             XCTAssertEqual(app.textFields["passwordTextField"].value as? String, password,
                            "Password field value is wrong",
                            file: file,
@@ -116,6 +117,30 @@ final class NifflerUITests: XCTestCase {
                           "Success message after registration doesn't appear",
                           file: file,
                           line: line)
+        }
+    }
+
+}
+
+extension XCUIApplication {
+    func hideKeyboardIfPresent(fallbackTapElementIdentifier: String? = nil) {
+        let keyboard = self.keyboards.element
+        guard keyboard.exists else { return }
+
+        // Попытка нажать кнопки на клавиатуре
+        if keyboard.buttons["Done"].exists {
+            keyboard.buttons["Done"].tap()
+        } else if keyboard.buttons["Return"].exists {
+            keyboard.buttons["Return"].tap()
+        } else if self.toolbars.buttons["Hide Keyboard"].exists {
+            // Для iPad — кнопка скрытия клавиатуры
+            self.toolbars.buttons["Hide Keyboard"].tap()
+        } else if let elementId = fallbackTapElementIdentifier, self.otherElements[elementId].exists {
+            // Фолбэк — тап по элементу, чтобы скрыть клавиатуру
+            self.otherElements[elementId].tap()
+        } else {
+            // Если всё остальное не сработало — попытка тапнуть в первое попавшееся безопасное место
+            self.otherElements.firstMatch.tap()
         }
     }
 }


### PR DESCRIPTION
Homework QA.GURU "16.3 Погружение: пишем тесты для сложных сценариев."
Есть два вопроса.

1. Тест с регистрацией и последующим логином пользователя ( `testUserSignUp` ), падает на логине, при повторном запуске, если не добавить:
```swift
let removeDate = Date().addingTimeInterval(-2*60*60)
HTTPCookieStorage.shared.removeCookies(since: removeDate)
``` 
в методе ` func setupForUITests()` приложения. Правильное ли это решение? (подсмотрел в апи тестах)

2. Тест `testAddSpend` не проходит для пользовталя у которого добавлены несколько трат и категорий: на экране добавления новой траты поле выбора категории просто отсутствует
<img width="232" alt="изображение" src="https://github.com/user-attachments/assets/d62a6111-b64a-420a-8490-f3111448ccbf" />
